### PR TITLE
Fix: Load missing fonts and icons

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Orbitron:wght@400..900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Adds <link> tags to client/index.html to:
- Import Orbitron and JetBrains Mono fonts from Google Fonts.
- Import FontAwesome CSS from a CDN.

This resolves issues where these resources were referenced in CSS and components but not loaded, causing fallbacks to system fonts and broken icons. The existing CSS utility classes for .font-orbitron and .font-mono will now correctly apply the intended typography.